### PR TITLE
 chore(gitignore): ignore artifacts/logs, script reports, and PR NOOP trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,17 @@ TestResults/
 # Artifacts that should be committed only when explicitly needed
 # Uncomment if you want to exclude certain artifacts folders:
 # artifacts/
+
+# --- Repo-specific transient files (keep clean commits) ---
+# Analysis/telemetry outputs and logs
+artifacts/**
+logs/**
+
+# Script-generated reports and logs
+scripts/*.json
+scripts/*_log.txt
+scripts/run_*_log.txt
+scripts/.tmp_pr_backup/**
+
+# PR NOOP trigger (used only to force a diff)
+scripts/.pr_trigger_for_pr.txt


### PR DESCRIPTION
VN: Dọn vệ sinh repo để tránh commit nhầm artifacts/logs và file tạm từ scripts; giúp lịch sử commit sạch và CI nhanh hơn. Không đổi logic, chỉ cập nhật .gitignore.
EN: Repo hygiene to prevent accidental commits of artifacts/logs and script-generated files. No functional code changes; .gitignore only.
What changed

Add ignores:
artifacts/**
logs/**
scripts/.json, scripts/log.txt, scripts/run*_log.txt
[.tmp_pr_backup](vscode-file://vscode-app/c:/Users/TechCare/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)**
scripts/.pr_trigger_for_pr.txt
Risk/Impact

Low risk, no runtime changes. CI unaffected.
Validation

git status stays clean after generating artifacts/logs locally.
Can revert by removing patterns or reverting this commit.
Reviewer checklist

 Only .gitignore changed
 Patterns match intent; no false positives for source files