### PR TITLE
CI Fix: Guard smoke wrapper missing + absolute paths

### DIFF
--- a/scripts/ops.ps1
+++ b/scripts/ops.ps1
@@ -7,7 +7,7 @@ function Invoke-Smoke60mMergeLatest {
         [string]$LogPath = "D:\botg\logs"
     )
     
-    & ".\scripts\run_smoke_60m_wrapper_v2.ps1" -MergeOnly -OutRoot $OutRoot -LogPath $LogPath
+    & (Find-SmokeWrapper) -MergeOnly -OutRoot $OutRoot -LogPath $LogPath
 }
 
 function Show-PhaseStats {


### PR DESCRIPTION
Adds guard to handle missing smoke wrapper files gracefully. Uses absolute paths and soft-fails unless CI_BLOCK_FAIL=1 is set.