### PR TITLE
CI(selftest): concurrency + job summary

### DIFF
--- a/.github/workflows/smoke-selftest.yml
+++ b/.github/workflows/smoke-selftest.yml
@@ -1,4 +1,9 @@
 ﻿name: smoke-selftest
+
+concurrency:
+  group: smoke-selftest-${{ github.ref }}
+  cancel-in-progress: true
+
 on: 
   pull_request:
     branches: [ main ]
@@ -41,6 +46,29 @@ jobs:
           
           Write-Host "=== Running self-test ==="
           .\scripts\ops_selftest.ps1
+          
+      - name: Summarize health-check
+        if: always()
+        shell: pwsh
+        run: |
+          $folder = Join-Path $PWD 'artifacts_ascii'
+          $latest = Get-ChildItem $folder -Filter 'health_check_*.json' -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $latest) {
+            "`n### Smoke selftest summary`n_No health JSON found_`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            exit 0
+          }
+          $j = Get-Content $latest.FullName -Raw | ConvertFrom-Json
+          $issues = if ($j.issues -and $j.issues.Count -gt 0) { ($j.issues | ForEach-Object { "- $_" }) -join "`n" } else { "_None_" }
+          $summary = @"
+          ### Smoke selftest summary
+          - **STATUS**: $($j.STATUS)
+          - **Can continue**: $($j.can_continue_running)
+          - **Reconstruct tool**: $($j.reconstruct_tool.present) ($($j.reconstruct_tool.path))
+          - **Issues**:
+          $issues
+          "@
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           
       - name: Upload self-test results
         if: always()

--- a/.github/workflows/smoke-selftest.yml.backup
+++ b/.github/workflows/smoke-selftest.yml.backup
@@ -1,0 +1,57 @@
+﻿name: smoke-selftest
+on: 
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"   # 08:00 ICT daily (adjust if needed)
+
+jobs:
+  selftest:
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas
+        
+      - name: Verify stdlib sqlite3
+        shell: pwsh
+        run: |
+          python - <<'PY'
+          import sqlite3, sys
+          print("sqlite3 OK, version:", sqlite3.sqlite_version)
+          PY
+        
+      - name: PowerShell ops.ps1 self-test
+        shell: pwsh
+        working-directory: ${{ github.workspace }}
+        env:
+          CI_BLOCK_FAIL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '1' || '0' }}
+        run: |
+          Write-Host "=== Loading ops.ps1 ==="
+          . .\scripts\ops.ps1
+          
+          Write-Host "=== Running self-test ==="
+          .\scripts\ops_selftest.ps1
+          
+      - name: Upload self-test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selftest-results
+          path: |
+            scripts/ops_selftest.ps1
+            .vscode/tasks.json
+            docs/RUNBOOK_smoke60m.md


### PR DESCRIPTION
- Add workflow concurrency (cancel in-progress per ref)
- Publish health-check summary to job page via $GITHUB_STEP_SUMMARY
- No trigger/guard changes; keeps CI_BLOCK_FAIL behavior