### PR TITLE
CI(selftest): add manual force_ok to exercise incident auto-close

### DIFF
--- a/.github/workflows/smoke-selftest.yml
+++ b/.github/workflows/smoke-selftest.yml
@@ -1,4 +1,4 @@
-﻿name: smoke-selftest
+name: smoke-selftest
 
 on:
   pull_request:
@@ -6,6 +6,11 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      force_ok:
+        description: "Force STATUS=OK to exercise auto-close path (manual only)"
+        type: boolean
+        default: false
   schedule:
     - cron: '0 1 * * *' # 01:00 UTC / 08:00 ICT
 
@@ -66,6 +71,21 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          # Override for manual dispatch test
+          $event = "${{ github.event_name }}"
+          $forceOk = "${{ inputs.force_ok || false }}"
+          if ($event -eq 'workflow_dispatch' -and $forceOk -eq 'true') {
+            $forced = @"
+          ### Smoke selftest summary (FORCED)
+          - **STATUS**: OK
+          - **Reason**: Manual dispatch with force_ok=true (incident auto-close exercise)
+          "@
+            $forced | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "status=OK" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "issues_count=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            return
+          }
+
           $folder = Join-Path $PWD 'artifacts_ascii'
           $latest = Get-ChildItem $folder -Filter 'health_check_*.json' -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending | Select-Object -First 1


### PR DESCRIPTION
### Summary

Add manual **force_ok** input to workflow_dispatch that allows forcing STATUS=OK for testing incident auto-close functionality.

### Changes

- **workflow_dispatch inputs**: Added orce_ok boolean parameter (default: false) 
- **Override logic**: Added check in 'Summarize health-check' step that forces STATUS=OK when orce_ok=true in manual dispatch
- **Green path testing**: Allows exercising incident auto-close without needing actual healthy condition

### Behavior

- **No impact on production**: push/schedule/pull_request events behave exactly as before
- **Manual testing only**: Override only works with workflow_dispatch + orce_ok=true
- **Incident conditions unchanged**: Open/close logic still uses same conditions (steps.sum.outputs.status != 'OK' and == 'OK')

### Usage

`powershell
gh workflow run smoke-selftest.yml --ref main -f force_ok=true
`

This will:
1. Show 'FORCED OK' status in job summary
2. Set status=OK and issues_count=0 outputs  
3. Trigger 'Close incident issue when healthy' step
4. Auto-close any open incidents with proper comment

Ready for verification testing after merge.