### PR TITLE
CI(selftest): guard force_ok to OWNER/MEMBER

### DIFF
--- a/.github/workflows/smoke-selftest.yml
+++ b/.github/workflows/smoke-selftest.yml
@@ -74,6 +74,18 @@ jobs:
           # Override for manual dispatch test
           $event = "${{ github.event_name }}"
           $forceOk = "${{ inputs.force_ok || false }}"
+          $actorOk = "${{ github.actor_association }}" -in @("OWNER","MEMBER")
+          if ($event -eq 'workflow_dispatch' -and $forceOk -eq 'true' -and -not $actorOk) {
+            $denied = @"
+          ### Smoke selftest summary (FORCED REQUEST DENIED)
+          - **STATUS**: UNKNOWN
+          - **Reason**: force_ok is restricted to repo OWNER/MEMBER
+          "@
+            $denied | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "status=UNKNOWN" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "issues_count=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            return
+          }
           if ($event -eq 'workflow_dispatch' -and $forceOk -eq 'true') {
             $forced = @"
           ### Smoke selftest summary (FORCED)


### PR DESCRIPTION
### Summary

Restrict manual force_ok usage to repo OWNER/MEMBER for security.

### Changes

- **Actor Guard**: Added check for github.actor_association in OWNER/MEMBER
- **Denial Logic**: If unauthorized user tries force_ok, shows FORCED REQUEST DENIED with STATUS=UNKNOWN  
- **Preserved Logic**: All existing incident conditions and production behavior unchanged

### Behavior

- **No impact on production**: push/schedule/PR events completely unaffected
- **Security hardening**: Only repo owners/members can use force_ok override
- **Clear denial feedback**: Unauthorized attempts get clear denial message

### Incident Logic Unchanged

- Open: steps.sum.outputs.status != OK 
- Close: steps.sum.outputs.status == OK 
- All permissions, triggers, and behavior preserved 

Ready for merge to harden force_ok access control.