### PR TITLE
docs: manual force_ok guard verification

### DIFF
--- a/docs/RUNBOOK_smoke60m.md
+++ b/docs/RUNBOOK_smoke60m.md
@@ -21,3 +21,15 @@ Run the self-test to verify operational readiness:
 Regular maintenance commands for keeping the system clean and operational.
 
 
+## Manual force_ok (owner-only)
+- Purpose: exercise incident auto-close logic without altering production triggers.
+- Command: `gh workflow run ".github/workflows/smoke-selftest.yml" --ref main -f force_ok=true`
+- Allowed actors: repository OWNER or MEMBER (`github.actor_association`). Expected step summary: `### Smoke selftest summary (FORCED)` with `STATUS: OK` and `Close incident issue when healthy` running.
+- Denied actors: COLLABORATOR/other => summary shows `FORCED REQUEST DENIED`, outputs `status=UNKNOWN`, and incident-close step remains skipped.
+- Inspect guard decisions via `gh run view <runId> --log --job <jobId> | Select-String "Summarize health-check"` to confirm association detection.
+
+## Guard verification checklist
+- [ ] Main branch CI (`ci.yml`) succeeds on the merged guard change.
+- [ ] Manual `force_ok=true` dispatch as OWNER/MEMBER returns STATUS=OK and triggers `Close incident issue when healthy`.
+- [ ] Any incident (e.g., `Selftest incident: ...`) is closed or commented with the healthy run link.
+- [ ] Post results to the guarding PR and update documentation/runbook links where applicable.


### PR DESCRIPTION
## Summary
- document manual orce_ok usage and guard expectations
- add guard verification checklist after guard changes

## Testing
- not applicable (docs only)