### PR TITLE
ci: gate24h workflow dispatch fix

### DIFF
--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -1,4 +1,4 @@
-﻿name: Gate 24h (paper supervised)
+name: Gate 24h (paper supervised)
 run-name: Gate 24h ${{ inputs.mode || 'paper' }}_${{ inputs.hours || '24' }}h @ ${{ inputs.source || 'manual' }}
 
 permissions:


### PR DESCRIPTION
Remove UTF-8 BOM from gate24h.yml so GitHub sees workflow_dispatch.