### PR TITLE
CI: normalize gate24h triggers (workflow_dispatch + push)

### DIFF
--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -1,4 +1,4 @@
-name: Gate 24h (paper supervised)
+﻿name: Gate 24h (paper supervised)
 run-name: Gate 24h ${{ inputs.mode || 'paper' }}_${{ inputs.hours || '24' }}h @ ${{ inputs.source || 'manual' }}
 
 permissions:
@@ -19,22 +19,22 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Operating mode"
+        description: "Run mode"
         required: true
         default: "paper"
       hours:
-        description: "Hours to run"
+        description: "Duration in hours"
         required: true
         default: "24"
       source:
-        description: "Trigger source"
+        description: "Source tag"
         required: false
   push:
     branches: [ main ]
     paths:
-      - '.github/workflows/gate24h.yml'
-      - 'path_issues/**'
-      - 'scripts/**'
+      - ".github/workflows/gate24h.yml"
+      - "path_issues/**"
+      - "scripts/**"
 jobs:
   gate24h:
     runs-on: [self-hosted, Windows, botg]
@@ -21469,6 +21469,7 @@ jobs:
         compression-level: 6
         overwrite: true
         retention-days: 7
+
 
 
 


### PR DESCRIPTION
Classic inputs (no typed schema), single 'on:' block; ensure GH recognizes workflow_dispatch.