### PR TITLE
CI: restore classic gate24h dispatch schema

### DIFF
--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -17,19 +17,6 @@ defaults:
 
 on:
   workflow_dispatch:
-    inputs:
-      mode:
-        description: 'Operating mode'
-        required: true
-        default: 'paper'
-      hours:
-        description: 'Hours to run'
-        required: true
-        default: '24'
-      source:
-        description: 'Trigger source'
-        required: false
-        default: 'manual'
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -19,22 +19,23 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Run mode"
+        description: 'Operating mode'
         required: true
-        default: "paper"
+        default: 'paper'
       hours:
-        description: "Duration in hours"
+        description: 'Hours to run'
         required: true
-        default: "24"
+        default: '24'
       source:
-        description: "Source tag"
+        description: 'Trigger source'
         required: false
+        default: 'manual'
   push:
     branches: [ main ]
     paths:
-      - ".github/workflows/gate24h.yml"
-      - "path_issues/**"
-      - "scripts/**"
+      - '.github/workflows/gate24h.yml'
+      - 'path_issues/**'
+      - 'scripts/**'
 
 jobs:
   gate24h:


### PR DESCRIPTION
Revert to classic descriptions/defaults while keeping schema untyped so workflow_dispatch stays recognized.