### PR TITLE
CI: strip literal CR markers from gate24h

### DIFF
--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -49,7 +49,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    \r\n
+    
+
     - name: Resolve inputs
       id: resolve
       shell: powershell


### PR DESCRIPTION
Remove escaped \\r\\n placeholders left in the workflow so YAML parses correctly.