### PR TITLE
CI: use Windows PowerShell for gate24h push-dispatch

### DIFF
--- a/.github/workflows/gate24h_main.yml
+++ b/.github/workflows/gate24h_main.yml
@@ -1,4 +1,4 @@
-﻿name: Gate 24h (paper supervised)
+name: Gate 24h (paper supervised)
 run-name: Gate 24h ${{ inputs.mode || 'paper' }}_${{ inputs.hours || '24' }}h @ ${{ inputs.source || 'manual' }}
 
 permissions:
@@ -49,7 +49,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Load run config from push-dispatch (if any)
       if: ${{ github.event_name == 'push' }}
-      shell: pwsh
+      shell: powershell
       run: |
         $dir = Join-Path $env:GITHUB_WORKSPACE 'path_issues/dispatch'
         if (Test-Path $dir) {
@@ -71,7 +71,7 @@ jobs:
 
     - name: Resolve inputs
       id: resolve
-      shell: pwsh
+      shell: powershell
       run: |
         $dispatchFile = 'path_issues/start_24h_command_ready.txt'
         $mode   = $env:MODE
@@ -142,7 +142,7 @@ jobs:
 
     - name: Capture start timestamp (pwsh)
       id: start
-      shell: pwsh
+      shell: powershell
       run: |
         $started = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
         "STARTED_AT=$started" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -278,7 +278,7 @@ jobs:
 
     - name: Emit sentinel (always)
       if: ${{ always() }}
-      shell: pwsh
+      shell: powershell
       env:
         MODE: ${{ steps.resolve.outputs.mode }}
         HOURS: ${{ steps.resolve.outputs.hours }}
@@ -349,7 +349,7 @@ jobs:
 
     - name: Close tracking issue (always)
       if: ${{ always() }}
-      shell: pwsh
+      shell: powershell
       run: |
         $issue = gh issue list --search "label:gate24h-tracking state:open" --json number --jq ".[0].number"
         if ($issue) {


### PR DESCRIPTION
Self-hosted runners lack `pwsh`; switch new push-dispatch steps back to Windows PowerShell shells.