### PR TITLE
fix(gate24h): increase timeout to 1500min (25h) for 24h runs

### DIFF
--- a/.github/workflows/gate24h_main.yml
+++ b/.github/workflows/gate24h_main.yml
@@ -1,4 +1,4 @@
-name: Gate 24h (paper supervised)
+﻿name: Gate 24h (paper supervised)
 run-name: Gate 24h ${{ inputs.mode || 'paper' }}_${{ inputs.hours || '24' }}h @ ${{ inputs.source || 'manual' }}
 
 permissions:
@@ -38,7 +38,7 @@ on:
 jobs:
   gate24h:
     runs-on: [self-hosted, Windows, botg]
-    timeout-minutes: 20
+    timeout-minutes: 1500
     
     concurrency:
       group: gate24h-${{ github.ref }}
@@ -451,3 +451,4 @@ jobs:
         compression-level: 6
         overwrite: true
         retention-days: 7
+


### PR DESCRIPTION
**Problem**: gate24h job had timeout-minutes: 20 (only 20 minutes) but needs to run for 24 hours.

**Solution**: Increased timeout-minutes to 1500 (25 hours) to allow 24h runs with buffer.

**Tested**: Will be verified in next 24h production run.