### PR TITLE
ci: notify workflow_dispatch + E2E driver

### DIFF
--- a/.github/workflows/notify_on_failure.yml
+++ b/.github/workflows/notify_on_failure.yml
@@ -3,36 +3,73 @@ on:
   workflow_run:
     workflows: ["Gate 24h (paper supervised)"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Gate24h run id"
+        required: true
+      conclusion:
+        description: "Gate24h conclusion"
+        required: true
+      url:
+        description: "Gate24h url"
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   notify:
-    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
     steps:
+      - name: Resolve vars (run info)
+        id: vars
+        shell: bash
+        env:
+          RUN_ID_WR: ${{ github.event.workflow_run.id }}
+          RUN_CONC_WR: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL_WR: ${{ github.event.workflow_run.html_url }}
+          RUN_ID_DISP: ${{ github.event.inputs.run_id }}
+          RUN_CONC_DISP: ${{ github.event.inputs.conclusion }}
+          RUN_URL_DISP: ${{ github.event.inputs.url }}
+        run: |
+          set -euo pipefail
+          RUN_ID="${RUN_ID_WR:-$RUN_ID_DISP}"
+          RUN_CONC="${RUN_CONC_WR:-$RUN_CONC_DISP}"
+          RUN_URL="${RUN_URL_WR:-$RUN_URL_DISP}"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_conc=$RUN_CONC" >> "$GITHUB_OUTPUT"
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "Resolved: id=$RUN_ID conc=$RUN_CONC url=$RUN_URL"
       - name: Telegram notify (if secrets)
-        if: ${{ secrets.TELEGRAM_BOT_TOKEN && secrets.TELEGRAM_CHAT_ID }}
-        id: tgram`r`n        uses: appleboy/telegram-action@4fde07eaa6fb2ab49ca1af1c65b9b9b5fd5ad1ce`r`n        timeout-minutes: 2`r`n        continue-on-error: true
-        with:
-          to:    ${{ secrets.TELEGRAM_CHAT_ID }}
-          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          message: |
+        id: tgram
+        env:
+          MSG: |
             ❌ Gate24h failed
             Repo: ${{ github.repository }}
-            RunID: ${{ github.event.workflow_run.id }}
-            Conclusion: ${{ github.event.workflow_run.conclusion }}
-            URL: ${{ github.event.workflow_run.html_url }}
+            RunID: ${{ steps.vars.outputs.run_id }}
+            Conclusion: ${{ steps.vars.outputs.run_conc }}
+            URL: ${{ steps.vars.outputs.run_url }}
+        if: ${{ env.TELEGRAM_BOT_TOKEN != '' && env.TELEGRAM_CHAT_ID != '' }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode text="$MSG" \
+            -d parse_mode=HTML >/dev/null
 
       - name: Issue alert (fallback)
-        if: steps.tgram.outcome != 'success'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
-        with:
-          script: |
-            const tit = 'Gate24h alerts (auto)';
-            const body = `❌ Gate24h failed
-            Conclusion: ${{ github.event.workflow_run.conclusion }}
-            URL: ${{ github.event.workflow_run.html_url }}`;
-            const {data: issues} = await github.rest.issues.listForRepo({owner: context.repo.owner, repo: context.repo.repo, state: 'open', per_page: 100});
-            let issue = issues.find(i => i.title === tit);
-            if (!issue) {
-              issue = (await github.rest.issues.create({owner: context.repo.owner, repo: context.repo.repo, title: tit, labels: ['gate-alert']})).data;
-            }
-            await github.rest.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body});
+        if: ${{ steps.tgram.outcome != 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="Gate24h alert: run #${{ steps.vars.outputs.run_id }} → ${{ steps.vars.outputs.run_conc }}"
+          BODY="${{ steps.vars.outputs.run_url }}"
+          gh issue create -R "$GITHUB_REPOSITORY" -t "$TITLE" -b "$BODY" -l gate-alert

--- a/scripts/ops_notify_e2e.ps1
+++ b/scripts/ops_notify_e2e.ps1
@@ -2,7 +2,8 @@ param(
   [string]$Hours = '0.1',
   [string]$Mode = 'paper',
   [switch]$FailFast,
-  [int]$WaitTimeoutSec = 600
+  [int]$WaitTimeoutSec = 600,
+  [string]$NotifyRef = 'ci/notify-dispatch-e2e'
 )
 
 # E2E notify test driver
@@ -71,8 +72,8 @@ if (-not $final) { throw 'Gate run did not reach a terminal conclusion in time' 
 Write-Host "Gate final: id=$($final.databaseId) conc=$($final.conclusion) url=$($final.url)"
 
 # Dispatch notify workflow with explicit inputs
-Write-Host 'Dispatching notify_on_failure via workflow_dispatch...'
-& gh workflow run ".github/workflows/notify_on_failure.yml" -f "run_id=$($final.databaseId)" -f "conclusion=$($final.conclusion)" -f "url=$($final.url)" | Write-Host
+Write-Host "Dispatching notify_on_failure via workflow_dispatch on ref '$NotifyRef'..."
+& gh workflow run ".github/workflows/notify_on_failure.yml" --ref "$NotifyRef" -f "run_id=$($final.databaseId)" -f "conclusion=$($final.conclusion)" -f "url=$($final.url)" | Write-Host
 $notifyStart = Get-Date
 
 function Get-LatestNotifyRun {

--- a/scripts/ops_notify_e2e.ps1
+++ b/scripts/ops_notify_e2e.ps1
@@ -1,0 +1,117 @@
+param(
+  [string]$Hours = '0.1',
+  [string]$Mode = 'paper',
+  [switch]$FailFast,
+  [int]$WaitTimeoutSec = 600
+)
+
+# E2E notify test driver
+# - Dispatch Gate24h with a test source to keep it in_progress or fail-fast
+# - Cancel/fail it to get a non-success conclusion
+# - Manually dispatch notify_on_failure with the run metadata
+# - Wait for notify run to complete, then show logs and any issue fallback
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-GH() {
+  if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw 'GitHub CLI (gh) is required. Install from https://cli.github.com and run gh auth login.'
+  }
+}
+
+function Wait-Until($ScriptBlock, [int]$TimeoutSec = 300, [int]$DelaySec = 5) {
+  $deadline = (Get-Date).AddSeconds($TimeoutSec)
+  while ((Get-Date) -lt $deadline) {
+    $val = & $ScriptBlock
+    if ($val) { return $val }
+    Start-Sleep -Seconds $DelaySec
+  }
+  return $null
+}
+
+Assert-GH
+
+$Source = if ($FailFast) { 'notify_test_fail' } else { 'notify_test' }
+
+Write-Host "Dispatching Gate24h (hours=$Hours mode=$Mode source=$Source)"
+& gh workflow run ".github/workflows/gate24h_main.yml" -f "hours=$Hours" -f "mode=$Mode" -f "source=$Source" | Write-Host
+$startAt = Get-Date
+
+# Find the latest Gate24h run created after $startAt
+function Get-LatestGateRun {
+  $runsJson = & gh run list --workflow ".github/workflows/gate24h_main.yml" --json databaseId,status,conclusion,createdAt,url,headBranch --limit 20
+  $runs = $null
+  try { $runs = $runsJson | ConvertFrom-Json } catch { $runs = @() }
+  $runs | Where-Object { [datetime]$_.createdAt -ge $startAt } | Sort-Object createdAt -Descending | Select-Object -First 1
+}
+
+$gateRun = Wait-Until { Get-LatestGateRun } -TimeoutSec 120 -DelaySec 3
+if (-not $gateRun) { throw 'No Gate24h run detected' }
+Write-Host "Gate run detected: id=$($gateRun.databaseId) status=$($gateRun.status) url=$($gateRun.url)"
+
+# If not fail-fast, wait until in_progress then cancel
+if (-not $FailFast) {
+  Write-Host 'Waiting for gate run to enter in_progress...'
+  $inprog = Wait-Until {
+    $r = Get-LatestGateRun
+    if ($r -and $r.status -eq 'in_progress') { $r } else { $null }
+  } -TimeoutSec 180 -DelaySec 3
+  if (-not $inprog) { Write-Warning 'Run did not reach in_progress in time; continuing anyway' }
+
+  Write-Host "Cancelling gate run $($gateRun.databaseId)"
+  & gh run cancel $gateRun.databaseId | Write-Host
+}
+
+# Wait for a terminal conclusion
+$final = Wait-Until {
+  $r = Get-LatestGateRun
+  if ($r -and ($r.conclusion -ne $null -and $r.conclusion -ne '')) { $r } else { $null }
+} -TimeoutSec $WaitTimeoutSec -DelaySec 5
+if (-not $final) { throw 'Gate run did not reach a terminal conclusion in time' }
+Write-Host "Gate final: id=$($final.databaseId) conc=$($final.conclusion) url=$($final.url)"
+
+# Dispatch notify workflow with explicit inputs
+Write-Host 'Dispatching notify_on_failure via workflow_dispatch...'
+& gh workflow run ".github/workflows/notify_on_failure.yml" -f "run_id=$($final.databaseId)" -f "conclusion=$($final.conclusion)" -f "url=$($final.url)" | Write-Host
+$notifyStart = Get-Date
+
+function Get-LatestNotifyRun {
+  $runsJson = & gh run list --workflow ".github/workflows/notify_on_failure.yml" --json databaseId,status,conclusion,createdAt,url --limit 20
+  $runs = $null
+  try { $runs = $runsJson | ConvertFrom-Json } catch { $runs = @() }
+  $runs | Where-Object { [datetime]$_.createdAt -ge $notifyStart } | Sort-Object createdAt -Descending | Select-Object -First 1
+}
+
+$notifyRun = Wait-Until { Get-LatestNotifyRun } -TimeoutSec 120 -DelaySec 3
+if (-not $notifyRun) { throw 'Notify run not found' }
+
+Write-Host "Waiting for notify run to complete: id=$($notifyRun.databaseId)"
+$notifyFinal = Wait-Until {
+  $r = Get-LatestNotifyRun
+  if ($r -and $r.status -eq 'completed') { $r } else { $null }
+} -TimeoutSec 180 -DelaySec 3
+if (-not $notifyFinal) { throw 'Notify run did not complete in time' }
+Write-Host "Notify final: id=$($notifyFinal.databaseId) conc=$($notifyFinal.conclusion) url=$($notifyFinal.url)"
+
+Write-Host "--- Notify logs (tail 120) ---"
+try {
+  $log = & gh run view $notifyFinal.databaseId --log
+  if ($log) {
+    $lines = $log -split "`n"
+    $tail = if ($lines.Length -gt 120) { $lines[(-120)..(-1)] } else { $lines }
+    $tail | ForEach-Object { Write-Host $_ }
+  }
+} catch {
+  Write-Warning $_
+}
+
+Write-Host "--- gate-alert issues (latest) ---"
+try {
+  $issuesJson = & gh issue list --label gate-alert --state all --limit 5 --json number,title,url,createdAt,state
+  $issues = $issuesJson | ConvertFrom-Json
+  if ($issues) { $issues | Format-Table number,title,state,createdAt,url -AutoSize | Out-String | Write-Host }
+} catch {
+  Write-Warning $_
+}
+
+Write-Host 'E2E notify test complete.'


### PR DESCRIPTION
## Mục tiêu
Thay thế phần stub (PLACEHOLDER) trong Gate 24h bằng supervisor thực sự:
- Vòng lặp bash theo phút, heartbeat comment định kỳ, early-stop, ghi log đầy đủ.

## Thay đổi chính
- Step “Run supervised 24h gate” → `id: supervise`, shell: bash.
- Heartbeat: gửi comment vào tracking issue mỗi HB_MINUTES phút (đọc từ repo variable).
- Early-stop: dừng sớm nếu ≥3 FAIL trong 10 vòng gần nhất (xuất `supervisor_status=FAIL_EARLY`).
- Ghi log `gate24h.log` (START/ITER/HB/EARLY_STOP/END), upload artifact.
- Bổ sung render ở bước “Close tracking issue” (trạng thái, số phút thực, totals).
- Giữ nguyên triggers: `workflow_dispatch` + file-trigger (push `path_issues/start_24h_command_ready.txt` trên `main`).

## Acceptance (DoD)
- Manual smoke: `mode=paper, hours=0.2` ⇒ có ≥1 HB comment, artifact chứa `gate24h.log` (≥10 dòng), `[END] status=OK`.
- Early-stop: đặt repo variable `TEST_FORCE_FAIL=1`, chạy `hours=0.2` ⇒ `supervisor_status=FAIL_EARLY`, log có `[EARLY_STOP]`.
- File-trigger (main): push `path_issues/start_24h_command_ready.txt` với:

mode=paper
hours=0.2
source=file-trigger

⇒ Run tự kích hoạt, có HB + log.

## Rủi ro & rollback
- Thấp, chỉ chạm workflow. Rollback = revert PR.
- Sau merge, commit rỗng để reindex nếu cần.

## Hướng dẫn test nhanh
```bash
# đặt HB 1 phút cho test nhanh
gh variable set HB_MINUTES --repo baosang12/BotG --body "1"

# 1) Manual
gh workflow run gate24h.yml --repo baosang12/BotG -f mode=paper -f hours=0.2 -f source=manual

# 2) Early-stop
gh variable set TEST_FORCE_FAIL --repo baosang12/BotG --body "1"
gh workflow run gate24h.yml --repo baosang12/BotG -f mode=paper -f hours=0.2 -f source=manual
gh variable delete TEST_FORCE_FAIL --repo baosang12/BotG

# 3) File-trigger (trên main)
printf "mode=paper\nhours=0.2\nsource=file-trigger\n" > path_issues/start_24h_command_ready.txt
git add path_issues/start_24h_command_ready.txt
git commit -m "test: trigger gate24h by file"
git push
```
