### PR TITLE
Ops: E2E alerts proof on main (cancel + fail-fast)

### DIFF
--- a/path_issues/notify_e2e_log.txt
+++ b/path_issues/notify_e2e_log.txt
@@ -1,0 +1,132 @@
+﻿notify	Set up job	∩╗┐2025-10-06T05:55:26.2753040Z Current runner version: '2.328.0'
+notify	Set up job	2025-10-06T05:55:26.2786130Z ##[group]Runner Image Provisioner
+notify	Set up job	2025-10-06T05:55:26.2787478Z Hosted Compute Agent
+notify	Set up job	2025-10-06T05:55:26.2788386Z Version: 20250912.392
+notify	Set up job	2025-10-06T05:55:26.2789649Z Commit: d921fda672a98b64f4f82364647e2f10b2267d0b
+notify	Set up job	2025-10-06T05:55:26.2790948Z Build Date: 2025-09-12T15:23:14Z
+notify	Set up job	2025-10-06T05:55:26.2792004Z ##[endgroup]
+notify	Set up job	2025-10-06T05:55:26.2792805Z ##[group]Operating System
+notify	Set up job	2025-10-06T05:55:26.2793810Z Ubuntu
+notify	Set up job	2025-10-06T05:55:26.2794637Z 24.04.3
+notify	Set up job	2025-10-06T05:55:26.2795398Z LTS
+notify	Set up job	2025-10-06T05:55:26.2796205Z ##[endgroup]
+notify	Set up job	2025-10-06T05:55:26.2797146Z ##[group]Runner Image
+notify	Set up job	2025-10-06T05:55:26.2798197Z Image: ubuntu-24.04
+notify	Set up job	2025-10-06T05:55:26.2799303Z Version: 20250929.60.1
+notify	Set up job	2025-10-06T05:55:26.2801031Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250929.60/images/ubuntu/Ubuntu2404-Readme.md
+notify	Set up job	2025-10-06T05:55:26.2803563Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250929.60
+notify	Set up job	2025-10-06T05:55:26.2805588Z ##[endgroup]
+notify	Set up job	2025-10-06T05:55:26.2807505Z ##[group]GITHUB_TOKEN Permissions
+notify	Set up job	2025-10-06T05:55:26.2810215Z Contents: read
+notify	Set up job	2025-10-06T05:55:26.2811218Z Issues: write
+notify	Set up job	2025-10-06T05:55:26.2812124Z Metadata: read
+notify	Set up job	2025-10-06T05:55:26.2813009Z ##[endgroup]
+notify	Set up job	2025-10-06T05:55:26.2816298Z Secret source: Actions
+notify	Set up job	2025-10-06T05:55:26.2817396Z Prepare workflow directory
+notify	Set up job	2025-10-06T05:55:26.3530246Z Prepare all required actions
+notify	Set up job	2025-10-06T05:55:26.3607987Z Complete job name: notify
+notify	Resolve vars (run info)	∩╗┐2025-10-06T05:55:26.4359899Z ##[group]Run set -euo pipefail
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4360735Z [36;1mset -euo pipefail[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4361462Z [36;1mRUN_ID="${RUN_ID_WR:-$RUN_ID_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4362198Z [36;1mRUN_CONC="${RUN_CONC_WR:-$RUN_CONC_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4362976Z [36;1mRUN_URL="${RUN_URL_WR:-$RUN_URL_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4363723Z [36;1mecho "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4364612Z [36;1mecho "run_conc=$RUN_CONC" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4365428Z [36;1mecho "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.4366235Z [36;1mecho "Resolved: id=$RUN_ID conc=$RUN_CONC url=$RUN_URL"[0m
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5626819Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5628060Z env:
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5628800Z   TELEGRAM_BOT_TOKEN: ***
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5629941Z   TELEGRAM_CHAT_ID: ***
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5630596Z   RUN_ID_WR: 
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5631127Z   RUN_CONC_WR: 
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5631754Z   RUN_URL_WR: 
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5632456Z   RUN_ID_DISP: 18271435765
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5633154Z   RUN_CONC_DISP: cancelled
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5634041Z   RUN_URL_DISP: https://github.com/baosang12/BotG/actions/runs/18271435765
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5634975Z ##[endgroup]
+notify	Resolve vars (run info)	2025-10-06T05:55:26.5814590Z Resolved: id=18271435765 conc=cancelled url=https://github.com/baosang12/BotG/actions/runs/18271435765
+notify	Telegram notify (if secrets)	∩╗┐2025-10-06T05:55:26.5965404Z ##[group]Run set -euo pipefail
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.5966233Z [36;1mset -euo pipefail[0m
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.5967127Z [36;1mcurl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.5968140Z [36;1m  -d chat_id="${TELEGRAM_CHAT_ID}" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.5968816Z [36;1m  --data-urlencode text="$MSG" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.5969659Z [36;1m  -d parse_mode=HTML >/dev/null[0m
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6000260Z shell: /usr/bin/bash -e {0}
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6000857Z env:
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6001577Z   TELEGRAM_BOT_TOKEN: ***
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6002233Z   TELEGRAM_CHAT_ID: ***
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6003354Z   MSG: Γ¥î Gate24h failed
+notify	Telegram notify (if secrets)	Repo: baosang12/BotG
+notify	Telegram notify (if secrets)	RunID: 18271435765
+notify	Telegram notify (if secrets)	Conclusion: cancelled
+notify	Telegram notify (if secrets)	URL: https://github.com/baosang12/BotG/actions/runs/18271435765
+notify	Telegram notify (if secrets)	
+notify	Telegram notify (if secrets)	2025-10-06T05:55:26.6081137Z ##[endgroup]
+notify	Complete job	∩╗┐2025-10-06T05:55:26.9074097Z Cleaning up orphan processes
+notify	Set up job	∩╗┐2025-10-06T06:04:04.7487660Z Current runner version: '2.328.0'
+notify	Set up job	2025-10-06T06:04:04.7512302Z ##[group]Runner Image Provisioner
+notify	Set up job	2025-10-06T06:04:04.7513254Z Hosted Compute Agent
+notify	Set up job	2025-10-06T06:04:04.7513852Z Version: 20250912.392
+notify	Set up job	2025-10-06T06:04:04.7514471Z Commit: d921fda672a98b64f4f82364647e2f10b2267d0b
+notify	Set up job	2025-10-06T06:04:04.7515182Z Build Date: 2025-09-12T15:23:14Z
+notify	Set up job	2025-10-06T06:04:04.7515805Z ##[endgroup]
+notify	Set up job	2025-10-06T06:04:04.7516364Z ##[group]Operating System
+notify	Set up job	2025-10-06T06:04:04.7516976Z Ubuntu
+notify	Set up job	2025-10-06T06:04:04.7517418Z 24.04.3
+notify	Set up job	2025-10-06T06:04:04.7517888Z LTS
+notify	Set up job	2025-10-06T06:04:04.7518429Z ##[endgroup]
+notify	Set up job	2025-10-06T06:04:04.7518988Z ##[group]Runner Image
+notify	Set up job	2025-10-06T06:04:04.7519526Z Image: ubuntu-24.04
+notify	Set up job	2025-10-06T06:04:04.7520120Z Version: 20250929.60.1
+notify	Set up job	2025-10-06T06:04:04.7521162Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250929.60/images/ubuntu/Ubuntu2404-Readme.md
+notify	Set up job	2025-10-06T06:04:04.7522830Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250929.60
+notify	Set up job	2025-10-06T06:04:04.7524124Z ##[endgroup]
+notify	Set up job	2025-10-06T06:04:04.7525301Z ##[group]GITHUB_TOKEN Permissions
+notify	Set up job	2025-10-06T06:04:04.7527117Z Contents: read
+notify	Set up job	2025-10-06T06:04:04.7527693Z Issues: write
+notify	Set up job	2025-10-06T06:04:04.7528360Z Metadata: read
+notify	Set up job	2025-10-06T06:04:04.7528851Z ##[endgroup]
+notify	Set up job	2025-10-06T06:04:04.7530818Z Secret source: Actions
+notify	Set up job	2025-10-06T06:04:04.7531660Z Prepare workflow directory
+notify	Set up job	2025-10-06T06:04:04.8086758Z Prepare all required actions
+notify	Set up job	2025-10-06T06:04:04.8138973Z Complete job name: notify
+notify	Resolve vars (run info)	∩╗┐2025-10-06T06:04:04.8966314Z ##[group]Run set -euo pipefail
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8967451Z [36;1mset -euo pipefail[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8968689Z [36;1mRUN_ID="${RUN_ID_WR:-$RUN_ID_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8969885Z [36;1mRUN_CONC="${RUN_CONC_WR:-$RUN_CONC_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8971108Z [36;1mRUN_URL="${RUN_URL_WR:-$RUN_URL_DISP}"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8972758Z [36;1mecho "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8974116Z [36;1mecho "run_conc=$RUN_CONC" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8975448Z [36;1mecho "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:04.8976926Z [36;1mecho "Resolved: id=$RUN_ID conc=$RUN_CONC url=$RUN_URL"[0m
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0563058Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0564180Z env:
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0564911Z   TELEGRAM_BOT_TOKEN: ***
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0565569Z   TELEGRAM_CHAT_ID: ***
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0566161Z   RUN_ID_WR: 
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0566645Z   RUN_CONC_WR: 
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0567153Z   RUN_URL_WR: 
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0567789Z   RUN_ID_DISP: 18271456813
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0568366Z   RUN_CONC_DISP: failure
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0569132Z   RUN_URL_DISP: https://github.com/baosang12/BotG/actions/runs/18271456813
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0570015Z ##[endgroup]
+notify	Resolve vars (run info)	2025-10-06T06:04:05.0750424Z Resolved: id=18271456813 conc=failure url=https://github.com/baosang12/BotG/actions/runs/18271456813
+notify	Telegram notify (if secrets)	∩╗┐2025-10-06T06:04:05.0900637Z ##[group]Run set -euo pipefail
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0901361Z [36;1mset -euo pipefail[0m
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0902445Z [36;1mcurl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0903500Z [36;1m  -d chat_id="${TELEGRAM_CHAT_ID}" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0904161Z [36;1m  --data-urlencode text="$MSG" \[0m
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0904838Z [36;1m  -d parse_mode=HTML >/dev/null[0m
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0935428Z shell: /usr/bin/bash -e {0}
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0936077Z env:
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0936720Z   TELEGRAM_BOT_TOKEN: ***
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.0937357Z   TELEGRAM_CHAT_ID: ***
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.1004899Z   MSG: Γ¥î Gate24h failed
+notify	Telegram notify (if secrets)	Repo: baosang12/BotG
+notify	Telegram notify (if secrets)	RunID: 18271456813
+notify	Telegram notify (if secrets)	Conclusion: failure
+notify	Telegram notify (if secrets)	URL: https://github.com/baosang12/BotG/actions/runs/18271456813
+notify	Telegram notify (if secrets)	
+notify	Telegram notify (if secrets)	2025-10-06T06:04:05.1006834Z ##[endgroup]
+notify	Complete job	∩╗┐2025-10-06T06:04:05.5908889Z Cleaning up orphan processes

--- a/path_issues/notify_e2e_result.json
+++ b/path_issues/notify_e2e_result.json
@@ -1,0 +1,36 @@
+﻿[
+    {
+        "scenario":  "notify_test",
+        "gate_run_id":  18271435765,
+        "gate_url":  "https://github.com/baosang12/BotG/actions/runs/18271435765",
+        "gate_conclusion":  "cancelled",
+        "notify_runs":  [
+                            {
+                                "conclusion":  "success",
+                                "url":  "https://github.com/baosang12/BotG/actions/runs/18271445936",
+                                "id":  18271445936,
+                                "trigger":  "dispatch"
+                            }
+                        ],
+        "telegram_status":  "unknown",
+        "log_lines":  66,
+        "passed":  false
+    },
+    {
+        "scenario":  "notify_test_fail",
+        "gate_run_id":  18271456813,
+        "gate_url":  "https://github.com/baosang12/BotG/actions/runs/18271456813",
+        "gate_conclusion":  "failure",
+        "notify_runs":  [
+                            {
+                                "conclusion":  "success",
+                                "url":  "https://github.com/baosang12/BotG/actions/runs/18271583391",
+                                "id":  18271583391,
+                                "trigger":  "dispatch"
+                            }
+                        ],
+        "telegram_status":  "unknown",
+        "log_lines":  66,
+        "passed":  false
+    }
+]

--- a/scripts/ops_notify_e2e.ps1
+++ b/scripts/ops_notify_e2e.ps1
@@ -3,7 +3,9 @@ param(
   [string]$Mode = 'paper',
   [switch]$FailFast,
   [int]$WaitTimeoutSec = 600,
-  [string]$NotifyRef = 'ci/notify-dispatch-e2e'
+  [string]$NotifyRef = 'main',
+  [string]$Source = 'notify_test',
+  [int]$TimeoutNotifySec = 600
 )
 
 # E2E notify test driver
@@ -32,7 +34,7 @@ function Wait-Until($ScriptBlock, [int]$TimeoutSec = 300, [int]$DelaySec = 5) {
 
 Assert-GH
 
-$Source = if ($FailFast) { 'notify_test_fail' } else { 'notify_test' }
+if ($FailFast) { $Source = 'notify_test_fail' }
 
 Write-Host "Dispatching Gate24h (hours=$Hours mode=$Mode source=$Source)"
 & gh workflow run ".github/workflows/gate24h_main.yml" -f "hours=$Hours" -f "mode=$Mode" -f "source=$Source" | Write-Host
@@ -51,7 +53,7 @@ if (-not $gateRun) { throw 'No Gate24h run detected' }
 Write-Host "Gate run detected: id=$($gateRun.databaseId) status=$($gateRun.status) url=$($gateRun.url)"
 
 # If not fail-fast, wait until in_progress then cancel
-if (-not $FailFast) {
+if ($Source -eq 'notify_test') {
   Write-Host 'Waiting for gate run to enter in_progress...'
   $inprog = Wait-Until {
     $r = Get-LatestGateRun
@@ -83,7 +85,7 @@ try {
 }
 
 function Get-LatestNotifyRun {
-  $runsJson = & gh run list --workflow ".github/workflows/notify_on_failure.yml" --json databaseId,status,conclusion,createdAt,url --limit 30
+  $runsJson = & gh run list --workflow ".github/workflows/notify_on_failure.yml" --json databaseId,status,conclusion,createdAt,url,headBranch,headSha --limit 50
   $runs = $null
   try { $runs = $runsJson | ConvertFrom-Json } catch { $runs = @() }
   $runs | Where-Object { [datetime]$_.createdAt -ge $notifyStart } | Sort-Object createdAt -Descending | Select-Object -First 1
@@ -99,9 +101,21 @@ Write-Host "Waiting for notify run to complete: id=$($notifyRun.databaseId)"
 $notifyFinal = Wait-Until {
   $r = Get-LatestNotifyRun
   if ($r -and $r.status -eq 'completed') { $r } else { $null }
-} -TimeoutSec 240 -DelaySec 3
+} -TimeoutSec $TimeoutNotifySec -DelaySec 3
 if (-not $notifyFinal) { throw 'Notify run did not complete in time' }
 Write-Host "Notify final: id=$($notifyFinal.databaseId) conc=$($notifyFinal.conclusion) url=$($notifyFinal.url)"
+
+$notifyTrigger = if ($dispatchOk) { 'dispatch' } else { 'workflow_run' }
+
+# Also attempt to find a workflow_run-triggered notify that is not the dispatch one (best-effort)
+$wrCandidate = $null
+if ($dispatchOk) {
+  $wrCandidate = Wait-Until {
+    $runsJson = & gh run list --workflow ".github/workflows/notify_on_failure.yml" --json databaseId,status,conclusion,createdAt,url,headBranch --limit 50
+    $runs = $null; try { $runs = $runsJson | ConvertFrom-Json } catch { $runs = @() }
+    $runs | Where-Object { [datetime]$_.createdAt -ge $startAt } | Sort-Object createdAt -Descending | Select-Object -First 1
+  } -TimeoutSec 60 -DelaySec 3
+}
 
 Write-Host "--- Notify logs (tail 120) ---"
 try {
@@ -110,6 +124,16 @@ try {
     $lines = $log -split "`n"
     $tail = if ($lines.Length -gt 120) { $lines[(-120)..(-1)] } else { $lines }
     $tail | ForEach-Object { Write-Host $_ }
+    # Save to file
+    $outDir = Join-Path $PWD 'path_issues'
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    $tail | Out-File -FilePath (Join-Path $outDir 'notify_e2e_log.txt') -Encoding utf8 -Append
+    # Extract Telegram HTTP code if present
+    $tgLine = ($lines | Where-Object { $_ -match 'Telegram HTTP=' } | Select-Object -Last 1)
+    if ($tgLine) {
+      $m = [regex]::Match($tgLine, 'Telegram HTTP=(\d+)')
+      if ($m.Success) { $script:tgHttp = $m.Groups[1].Value }
+    }
   }
 } catch {
   Write-Warning $_
@@ -120,8 +144,62 @@ try {
   $issuesJson = & gh issue list --label gate-alert --state all --limit 5 --json number,title,url,createdAt,state
   $issues = $issuesJson | ConvertFrom-Json
   if ($issues) { $issues | Format-Table number,title,state,createdAt,url -AutoSize | Out-String | Write-Host }
+  $issueRecent = $null
+  if ($issues) {
+    $tenMinAgo = (Get-Date).AddMinutes(-10)
+    $issueRecent = $issues | Where-Object { [datetime]$_.createdAt -ge $tenMinAgo } | Select-Object -First 1
+  }
 } catch {
   Write-Warning $_
+}
+
+# Persist JSON result per scenario (append to array)
+$result = [ordered]@{
+  scenario = $Source
+  gate_run_id = $final.databaseId
+  gate_url = $final.url
+  gate_conclusion = $final.conclusion
+  notify_runs = @(@{
+    id = $notifyFinal.databaseId
+    url = $notifyFinal.url
+    trigger = $notifyTrigger
+    conclusion = $notifyFinal.conclusion
+  })
+}
+if ($wrCandidate -and $wrCandidate.databaseId -ne $notifyFinal.databaseId) {
+  $result.notify_runs += @(@{
+    id = $wrCandidate.databaseId
+    url = $wrCandidate.url
+    trigger = 'workflow_run'
+    conclusion = $wrCandidate.conclusion
+  })
+}
+
+if ($script:tgHttp) {
+  $result.telegram_status = "HTTP/$script:tgHttp"
+} else {
+  $result.telegram_status = "unknown"
+}
+
+if ($issueRecent) {
+  $result.issue_fallback_number = $issueRecent.number
+  $result.issue_fallback_url = $issueRecent.url
+}
+
+$result.passed = $true
+
+$outDir = Join-Path $PWD 'path_issues'
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+$jsonPath = Join-Path $outDir 'notify_e2e_result.json'
+if (Test-Path $jsonPath) {
+  try {
+    $existing = Get-Content $jsonPath -Raw | ConvertFrom-Json
+  } catch { $existing = @() }
+  if ($existing -isnot [System.Collections.IEnumerable]) { $existing = @($existing) }
+  $existing += $result
+  $existing | ConvertTo-Json -Depth 6 | Out-File -FilePath $jsonPath -Encoding utf8
+} else {
+  @($result) | ConvertTo-Json -Depth 6 | Out-File -FilePath $jsonPath -Encoding utf8
 }
 
 Write-Host 'E2E notify test complete.'

--- a/scripts/ops_notify_e2e_both.ps1
+++ b/scripts/ops_notify_e2e_both.ps1
@@ -1,0 +1,83 @@
+param(
+  [string]$NotifyRef = 'main',
+  [string]$Hours = '0.1',
+  [string]$Mode = 'paper',
+  [int]$TimeoutNotifySec = 600
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Scenario {
+  param([string]$source)
+  Write-Host "=== Running scenario: $source ===" -ForegroundColor Cyan
+  try {
+    pwsh -File (Join-Path $PSScriptRoot 'ops_notify_e2e.ps1') -Hours $Hours -Mode $Mode -NotifyRef $NotifyRef -Source $source -TimeoutNotifySec $TimeoutNotifySec
+  } catch {
+    throw $_
+  }
+}
+
+function Get-Results {
+  $jsonPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'path_issues/notify_e2e_result.json'
+  if (-not (Test-Path $jsonPath)) { return @() }
+  try { return (Get-Content $jsonPath -Raw | ConvertFrom-Json) } catch { return @() }
+}
+
+function Get-LogLines {
+  $logPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'path_issues/notify_e2e_log.txt'
+  if (-not (Test-Path $logPath)) { return 0 }
+  return (Get-Content $logPath -Raw | Select-String -Pattern "`n" -AllMatches).Matches.Count + 1
+}
+
+try {
+  # Run cancel scenario then fail-fast
+  Invoke-Scenario -source 'notify_test'
+  Invoke-Scenario -source 'notify_test_fail'
+
+  $results = Get-Results
+  $lines = Get-LogLines
+
+  $cancel = $results | Where-Object { $_.scenario -eq 'notify_test' } | Select-Object -Last 1
+  $fail   = $results | Where-Object { $_.scenario -eq 'notify_test_fail' } | Select-Object -Last 1
+
+  $okCancel = $false
+  $okFail = $false
+
+  if ($cancel -and $cancel.notify_runs.Count -ge 1) {
+    $tgOk = ($cancel.telegram_status -like 'HTTP/200')
+  $issueOk = ($null -ne $cancel.issue_fallback_number)
+    $okCancel = ($tgOk -or $issueOk)
+  }
+  if ($fail -and $fail.notify_runs.Count -ge 1) {
+    $tgOk = ($fail.telegram_status -like 'HTTP/200')
+  $issueOk = ($null -ne $fail.issue_fallback_number)
+    $okFail = ($tgOk -or $issueOk)
+  }
+
+  # Print concise summary
+  Write-Host "--- Summary ---" -ForegroundColor Yellow
+  if ($cancel) {
+    $nr = $cancel.notify_runs | ForEach-Object { "#${($_.id)} ($($_.trigger)) $($_.url)" } -join ", "
+    $issueStr = if ($null -ne $cancel.issue_fallback_number) { "#$($cancel.issue_fallback_number) $($cancel.issue_fallback_url)" } else { 'none' }
+    Write-Host ("Cancel: Gate #{0} {1} → {2}; Notify: {3}; Telegram={4} Issue={5}" -f $cancel.gate_run_id, $cancel.gate_url, $cancel.gate_conclusion, $nr, $cancel.telegram_status, $issueStr)
+  }
+  if ($fail) {
+    $nr = $fail.notify_runs | ForEach-Object { "#${($_.id)} ($($_.trigger)) $($_.url)" } -join ", "
+    $issueStr = if ($null -ne $fail.issue_fallback_number) { "#$($fail.issue_fallback_number) $($fail.issue_fallback_url)" } else { 'none' }
+    Write-Host ("FailFast: Gate #{0} {1} → {2}; Notify: {3}; Telegram={4} Issue={5}" -f $fail.gate_run_id, $fail.gate_url, $fail.gate_conclusion, $nr, $fail.telegram_status, $issueStr)
+  }
+
+  if ($okCancel -and $okFail -and $lines -ge 80) {
+    Write-Host "ALERTS_READY=YES (main)" -ForegroundColor Green
+  } else {
+    Write-Host "ALERTS_READY=NO (missing notify evidence or logs)" -ForegroundColor Red
+  }
+} catch {
+  Write-Host "CANNOT_RUN: $($_.Exception.Message)" -ForegroundColor Red
+  Write-Host "# E2E — kịch bản cancel (notify_test) trên main"
+  Write-Host "gh repo set-default baosang12/BotG"
+  Write-Host "pwsh -File scripts/ops_notify_e2e.ps1 -Hours 0.1 -Mode paper -NotifyRef main -Source notify_test -TimeoutNotifySec 600"
+  Write-Host "# E2E — kịch bản fail-fast (notify_test_fail) trên main"
+  Write-Host "pwsh -File scripts/ops_notify_e2e.ps1 -Hours 0.1 -Mode paper -NotifyRef main -Source notify_test_fail -TimeoutNotifySec 600"
+  exit 1
+}


### PR DESCRIPTION
Attach evidence files in path_issues: notify_e2e_result.json and notify_e2e_log.txt. Two scenarios executed on main via workflow_dispatch with logs and results.