### PR TITLE
ci(gate2): skip postrun on guard-fail

### DIFF
--- a/.github/workflows/gate24h.yml
+++ b/.github/workflows/gate24h.yml
@@ -141,7 +141,7 @@ jobs:
           Write-Host "orders.csv last updated $([math]::Round($ageMinutes,2)) minutes ago with $lineCount lines"
 
       - name: Postrun collect and validate
-        if: always()
+        if: ${{ always() && steps.assert.outputs.assert_fail != 'true' }}
         shell: powershell
         run: |
           & scripts\postrun_collect.ps1 -RunDir "$env:RUN_DIR"


### PR DESCRIPTION
Skip postrun_collect & postrun_gate2_validate khi steps.assert.outputs.assert_fail=='true'. Giữ evidence early run_metadata. Label: A-Builder.